### PR TITLE
feat: 게시물 저장 api 연결

### DIFF
--- a/src/components/Community/BoardComponent.jsx
+++ b/src/components/Community/BoardComponent.jsx
@@ -27,7 +27,6 @@ const BoardComponent = ({ boardTypeList = [], boardList = [] }) => {
     }, [selectedType]);
 
     const handlePosts = () => {
-        alert('글쓰러가기');
         navigate('/editor');
     };
 

--- a/src/components/Community/CommunityDetail.jsx
+++ b/src/components/Community/CommunityDetail.jsx
@@ -9,7 +9,7 @@ const CommunityDetail = () => {
             title: 'ㄴㅇㄻㄴㅇㄹㄹㄴㅇㄹ',
             author: '작성자',
             boardType: '바프',
-            content: '<p>ㅁㄴㅇㄻㄴㅇㄹ</p><p>ㅁㄴㅇㄻㄴㅇㄹ</p>'
+            content: '<p>hi<p>'
         });
     const [answerList, setAnswerList] = useState([
         {

--- a/src/components/Community/CommunityEditor.jsx
+++ b/src/components/Community/CommunityEditor.jsx
@@ -1,62 +1,61 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import TipTapEditor from '../Common/TipTapEditor';
+import ApiClient from '../../services/ApiClient';
 
 const CommunityEditor = () => {
     const [title, setTitle] = useState("");
     const [content, setContent] = useState(null);
+    const [communityType, setCommunityType] = useState("바프");
     const [images, setImages] = useState([]);
+    const [isSaving, setIsSaving] = useState(false);
     const navigate = useNavigate();
 
     const handleImageUpload = (file) => {
         setImages((prev) => [...prev, file]);
     };
 
-    //TODO: 백서버 만든후 변경할것 (25/02/11_김민준)
     const handleSave = async () => {
         try {
             if (!content) return alert('내용을 입력하세요');
-
-            /*const formdata = new FormData();
-            images.forEach(image => formdata.append('contentImageFiles', image));
+            setIsSaving(true);
+            const formData = new FormData();
+            if (images.length > 0) {
+                images.forEach(image => formData.append("contentImageFiles", image));
+            }
 
             //게시글에 포함된 이미지파일을 백서버에 저장
-            const response = await fetch("/api/upload-images", {
-                method: "POST",
-                body: formData,
-            });
-
+            const response = await ApiClient.post("/user/community/uploadContentImages",
+                formData,
+                { headers: { "Content-Type": "multipart/form-data" } }
+            );
             //이미지파일 저장후 url를 response로 받고 blob으로 시작하는 주소를 변경
-            const data = await Response.json();
-            if (data.imageUrls) {
+            if (response.data) {
                 let updatedContent = content;
-                data.imageUrls.forEach((url) => {
-                    updatedContent = updatedContent.replace("blob:", url);
+                response.data.forEach((url) => {
+                    updatedContent = updatedContent.replace(/blob:[^"]+/, url); //blob으로 시작하고 "전까지의 내용을 url로 변경
                 });
+
+                const requestData = {
+                    communityTitle: title,
+                    communityContent: updatedContent,
+                    communityType: communityType,
+                };
 
                 //img 태그의 이미지 주소 변경후 백에 제목과 함께 콘텐츠 저장
-                const saveResponse = await fetch("/api/save-post", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ title, content: updatedContent }),
-                });
+                const saveResponse = await ApiClient.post("/user/community/createCommunity", requestData);
 
-                //게시글 내용 저장 성공시 success 반환
-                const saveData = await saveResponse.json();
-                if (saveData.success) {
-                    alert("게시글이 저장되었습니다!");
-                    navigate('/community'); // 저장 후 이동
-                }
-            }*/
-            console.log("title: " + title + "/" + "content: " + content);
-            alert("게시글이 저장되었습니다!");
-            navigate('/community');
+                alert(saveResponse.data.message);
+                navigate('/community'); // 저장 후 이동
+            }
         } catch (error) {
             console.error("게시글 저장 실패:", error);
+        } finally {
+            setIsSaving(false);
         }
     };
     return (
-        <div className="p-4">
+        <div className="relative p-4">
             <h1 className="text-xl font-bold mb-2">게시글 작성</h1>
             <input
                 type="text"
@@ -65,8 +64,27 @@ const CommunityEditor = () => {
                 onChange={(e) => setTitle(e.target.value)}
                 className="border p-2 w-full mb-4"
             />
+            <select
+                className='w-[120px] h-[40px] px-2 text-xs'
+                value={communityType}
+                onChange={(e) => setCommunityType(e.target.value)}
+            >
+                <option>바프</option>
+                <option>일상</option>
+                <option>등등</option>
+                <option>기타</option>
+            </select>
             <TipTapEditor content={content} onChange={setContent} onImageUpload={handleImageUpload} />
             <button onClick={handleSave} className="mt-4 bg-blue-500 text-white px-4 py-2">저장</button>
+
+            {isSaving && (
+                <div className="absolute top-0 left-0 w-full h-full bg-gray-500 opacity-40 z-10"></div>
+            )}
+            {isSaving && (
+                <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center z-20">
+                    <div className="animate-spin rounded-full border-4 border-t-4 border-blue-500 w-16 h-16"></div>
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
close #<이슈 번호> <!-- 예: close #123 -->

## 🛠️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항
<!--- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## Sourcery 요약

커뮤니티 게시물 생성 API를 프론트엔드에 연결하여 사용자가 제목, 내용, 이미지 및 커뮤니티 유형과 함께 게시물을 저장할 수 있도록 합니다. 또한 저장 과정 중에 로딩 표시기를 추가합니다.

새로운 기능:
- 사용자 생성 콘텐츠 저장을 위한 커뮤니티 게시물 생성 API 엔드포인트 통합.
- 게시물 저장 과정 중에 시각적 피드백을 제공하기 위한 로딩 표시기 구현.
- 게시물을 분류하기 위한 커뮤니티 유형 선택 드롭다운 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Connects the community post creation API to the frontend, allowing users to save posts with titles, content, images, and community types. Also, it adds a loading indicator during the saving process.

New Features:
- Integrates the community post creation API endpoint for saving user-generated content.
- Implements a loading indicator to provide visual feedback during the post saving process.
- Adds a community type selection dropdown to categorize posts.

</details>